### PR TITLE
Use unsafe cell to fix miri failing and potential unsoundness

### DIFF
--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -2,11 +2,16 @@ use bumpslab::BumpSlab;
 
 #[test]
 fn basic_works() {
+    #[derive(Debug, PartialEq, Eq)]
     struct Thing(usize);
 
     let slab = BumpSlab::new();
 
-    slab.push(Thing(0));
+    let slot = slab.push(Thing(0));
+    unsafe {
+        assert_eq!(&*slot.ptr(), &Thing(0));
+        assert_eq!(&mut *slot.ptr_mut(), &mut Thing(0));
+    }
     slab.push(Thing(1));
     slab.push(Thing(2));
     slab.push(Thing(3));


### PR DESCRIPTION
This removes the transmute from *const _ to *mut _ which fails miri (try running clippy on the modified simple test) and instead uses UnsafeCell.