### PR TITLE
Reduce unsafe usage and fix unsoundness when the slab's linked list is empty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ authors = ["Jonathan Kelley <jkelleyrtp@gmail.com>"]
 
 [dependencies]
 bumpalo = { version = "3.11.1" }
+
+[dev-dependencies]
+rand = { version = "0.8.4", features = ["small_rng"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,13 +48,9 @@ impl<'a, T> BumpSlab<T> {
         // Drop the value
         unsafe { ManuallyDrop::drop(&mut slot.0.value) };
 
-        let next = self.next.get();
-
-        if let Some(next) = next {
-            // Assign the next item in the linked list
-            // point this slot to the head, and then the bumpslab head to the new slot
-            slot.0.next = Some(next);
-        }
+        // Assign the next item in the linked list
+        // point this slot to the head, and then the bumpslab head to the new slot
+        slot.0.next = self.next.get();
         self.next.set(Some(slot.0.into()));
     }
 }

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -8,11 +8,20 @@ fn fuzzing() {
     for _ in 0..1000 {
         if rand::random() {
             for _ in 0..rand::random::<usize>() % 10 {
-                values.push(slab.push(0));
+                let slot = slab.push(1234);
+                unsafe {
+                    assert_eq!(&*slot.ptr(), &1234);
+                }
+                values.push(slot);
             }
         } else {
             for _ in 0..rand::random::<usize>() % 10 {
-                if let Some(slot) = values.pop() {
+                if !values.is_empty() {
+                    let idx = rand::random::<usize>() % values.len();
+                    unsafe {
+                        assert_eq!(&*values[idx].ptr(), &1234);
+                    }
+                    let slot = values.remove(idx);
                     slab.remove(slot);
                 }
             }

--- a/tests/fuzzing.rs
+++ b/tests/fuzzing.rs
@@ -1,0 +1,21 @@
+use bumpslab::BumpSlab;
+
+#[test]
+fn fuzzing() {
+    let slab = BumpSlab::new();
+
+    let mut values = Vec::new();
+    for _ in 0..1000 {
+        if rand::random() {
+            for _ in 0..rand::random::<usize>() % 10 {
+                values.push(slab.push(0));
+            }
+        } else {
+            for _ in 0..rand::random::<usize>() % 10 {
+                if let Some(slot) = values.pop() {
+                    slab.remove(slot);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When the slab's linked list is empty, the current code returns early without setting next of the SlotInner resulting in the memory of the old value being interpreted as a pointer which is unsafe.

This also adds a fuzzing test, and uses Option<NonNull<_>> and typed pointers instead of null pointers.